### PR TITLE
Tweak format of slack messages

### DIFF
--- a/robots/assigned.go
+++ b/robots/assigned.go
@@ -87,7 +87,7 @@ func (r AssignedBot) DeferredAction(p *Payload) {
 	service := githubservice.New(AssignedConfig.PersonalAccessToken)
 	issues, err := service.AssignedTo(AssignedConfig.Owner, repo, username)
 
-	attachments := BuildAttachmentsShowRepo(issues, true, err)
+	attachments := BuildAttachmentsShowRepo(issues, true, false, err)
 
 	var text string = "Assigned to *" + username + "* for repo *" + repo + "*"
 

--- a/robots/definitions.go
+++ b/robots/definitions.go
@@ -60,7 +60,7 @@ type Attachment struct {
 	Text       string            `json:"text,omitempty"`
 	Color      string            `json:"color,omitempty"`
 	Fields     []AttachmentField `json:"fields,omitempty"`
-	MarkdownIn []MarkdownField   `json:"mrkdown_in,omitempty"`
+	MarkdownIn []MarkdownField   `json:"mrkdwn_in,omitempty"`
 	Title      string            `json:"title,omitempty"`
 	TitleLink  string            `json:"title_link,omitempty"`
 }

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -98,10 +98,10 @@ func (i *IncomingWebhook) Send() error {
 }
 
 func BuildAttachments(issues []github.Issue, err error) []Attachment {
-	return BuildAttachmentsShowRepo(issues, false, err)
+	return BuildAttachmentsShowRepo(issues, false, true, err)
 }
 
-func BuildAttachmentsShowRepo(issues []github.Issue, showrepo bool, err error) []Attachment {
+func BuildAttachmentsShowRepo(issues []github.Issue, showrepo bool, showAssigned bool, err error) []Attachment {
 
 	var attachments []Attachment
 
@@ -110,12 +110,12 @@ func BuildAttachmentsShowRepo(issues []github.Issue, showrepo bool, err error) [
 
 			for _, issue := range issues {
 
-				var name string
+				var assigned string
 
 				if issue.Assignee != nil {
-					name = *issue.Assignee.Login
+					assigned = "Assigned to *" + *issue.Assignee.Login + "*"
 				} else {
-					name = "Unassigned"
+					assigned = "*Unassigned*"
 				}
 
 				var color string = "#A0A0A0"
@@ -137,17 +137,31 @@ func BuildAttachmentsShowRepo(issues []github.Issue, showrepo bool, err error) [
 					}
 				}
 
-				var title string = "Issue #" + strconv.Itoa(*issue.Number) + ", " + name + " [" + joinedLabels + "]"
+				var title string = "Issue #" + strconv.Itoa(*issue.Number) + ", " + *issue.Title
 
+				var text string = ""
+				if showAssigned {
+					text += assigned
+				}
 				if issue.Milestone != nil {
-					title += " - " + *issue.Milestone.Title
+					if showAssigned {
+						text += " for "
+					}
+					text += *issue.Milestone.Title
 				}
 
+				if len(joinedLabels) > 0 {
+					text += " - [" + joinedLabels + "]"
+				}
+
+				markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
+
 				attachment := &Attachment{
-					Title:     title,
-					TitleLink: *issue.HTMLURL,
-					Text:      *issue.Title,
-					Color:     color,
+					Title:      title,
+					TitleLink:  *issue.HTMLURL,
+					Text:       text,
+					Color:      color,
+					MarkdownIn: markdownFields,
 				}
 
 				attachments = append(attachments, *attachment)


### PR DESCRIPTION
Modified message format so that the issue number and name are in the first line. Also show optional fields (assignee, milestone, labels) on the second line.

Here is an example of what it looks like:

![screen shot 2015-04-30 at 3 36 56 pm](https://cloud.githubusercontent.com/assets/135034/7423837/c5cec5d6-ef4e-11e4-9cbb-79eaff211ba2.png)


