### PR TITLE
Report long running PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create the `config.json` and `github.json` files and put your specific slack and
 
 ```
 { 
-        "domain": "robotsandpencils", 
+        "domain": "YOUR SLACK DOMAIN HERE", 
         "port": 4444, 
         "webhookpath": "RNP SLACK WEBHOOKPATH HERE"
 }
@@ -40,7 +40,7 @@ Create the `config.json` and `github.json` files and put your specific slack and
 
 ```
 { 
-        "owner": "RobotsAndPencils",
+        "owner": "YOUR GITHUB ID HERE",
         "personalAccessToken": "YOUR GITHUB ACCESS TOKEN HERE" 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,41 @@ or
 
 # Running Locally
 
-Edit the `config.json` and `github.json` files and put your specific slack and github information into it. Then, you can run
+Setup your go environment and make sure you have the `$GOPATH` variable defined as well as include `$GOPATH/bin` in your `$PATH`.
+
+Pull down the latest source code from Github for Marvin and after you should be able to see the files under `$GOPATH/src` directory
+
+```
+go get github.com/RobotsAndPencils/marvin
+```
+
+Create the `config.json` and `github.json` files and put your specific slack and github information into it. 
+
+## config.json
+
+```
+{ 
+        "domain": "robotsandpencils", 
+        "port": 4444, 
+        "webhookpath": "RNP SLACK WEBHOOKPATH HERE"
+}
+```
+
+## github.json
+
+```
+{ 
+        "owner": "RobotsAndPencils",
+        "personalAccessToken": "YOUR GITHUB ACCESS TOKEN HERE" 
+}
+```
+
+Then, you can run/test the programs locally after initializing 
 
 ```
 make init
 make run
+make test
 ```
 
 To test, use a web posting tool like `Postman` to sent a POST to `http://localhost:4444/slack` with `x-www-form-urlencoded` with at least a `command` and `text` parameters. For example:

--- a/githubservice/githubservice.go
+++ b/githubservice/githubservice.go
@@ -34,13 +34,16 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 	return token, nil
 }
 
-func (g *GithubService) loadIssuesForAssignee(owner string, assignee string) ([]github.Issue, error) {
+func (g *GithubService) obtainAuthenticatedClient() (c *github.Client) {
 	tokenSource := &TokenSource{
 		AccessToken: g.PersonalAccessToken,
 	}
 	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
-	client := github.NewClient(oauthClient)
+	return github.NewClient(oauthClient)
+}
 
+func (g *GithubService) loadIssuesForAssignee(owner string, assignee string) ([]github.Issue, error) {
+	var client = g.obtainAuthenticatedClient()
 	var all []github.Issue
 	var e error
 	opt := &github.SearchOptions{
@@ -69,12 +72,7 @@ func (g *GithubService) loadIssuesForAssignee(owner string, assignee string) ([]
 }
 
 func (g *GithubService) loadIssuesForRepo(owner string, repo string, assigned string) ([]github.Issue, error) {
-	tokenSource := &TokenSource{
-		AccessToken: g.PersonalAccessToken,
-	}
-	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
-	client := github.NewClient(oauthClient)
-
+	var client = g.obtainAuthenticatedClient()
 	var allIssues []github.Issue
 	var e error
 	opt := &github.IssueListByRepoOptions{
@@ -126,12 +124,7 @@ func (g *GithubService) makeIssueList(owner string, repo string, assigned string
 }
 
 func (g *GithubService) loadReposForOrganization(owner string) ([]github.Repository, error) {
-	tokenSource := &TokenSource{
-		AccessToken: g.PersonalAccessToken,
-	}
-	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
-	client := github.NewClient(oauthClient)
-
+	var client = g.obtainAuthenticatedClient()
 	var allRepos []github.Repository
 	var e error
 	opt := &github.RepositoryListByOrgOptions{
@@ -187,12 +180,7 @@ func (g *GithubService) findActiveReposForOrganization(owner string, days int) (
 }
 
 func (g *GithubService) findPRsForRepo(owner string, repo string) ([]github.PullRequest, error) {
-	tokenSource := &TokenSource{
-		AccessToken: g.PersonalAccessToken,
-	}
-	oauthClient := oauth2.NewClient(context.TODO(), tokenSource)
-	client := github.NewClient(oauthClient)
-
+	var client = g.obtainAuthenticatedClient()
 	var allPRs []github.PullRequest
 	var e error
 	opt := &github.PullRequestListOptions{

--- a/githubservice/githubservice.go
+++ b/githubservice/githubservice.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"sort"
-	"strconv"
 	"time"
 )
 

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -19,7 +19,28 @@ func Test(t *testing.T) {
 	s := New("PERSONAL ACCESS TOKEN HERE")
 
 	g.Describe("Github Service", func() {
+		daysOfActivity := 4
 
+		g.It("Should find repos for RobotsAndPencils", func() {
+			repos, err := s.findActiveReposForOrganization("RobotsAndPencils", daysOfActivity)
+
+			Expect(repos).ToNot(BeNil())
+			Expect(err).To(BeNil())
+			
+			fmt.Println("Active repositories = " + strconv.Itoa(len(repos)))
+		})
+		
+		g.It("Should find open pull requests for repos in RobotsAndPencils", func() {
+			pullRequests, err := s.findOpenPRsForOrganization("RobotsAndPencils", daysOfActivity)
+
+			Expect(pullRequests).ToNot(BeNil())
+			Expect(err).To(BeNil())
+			
+			fmt.Println("Active repositories that have open PRs = " + strconv.Itoa(len(pullRequests)))
+			
+			Expect(5).To(BeEquivalentTo(4))
+		})
+		
 		g.It("Should find product backlog items in marvin", func() {
 			issues, err := s.Backlog("RobotsAndPencils", "marvin")
 
@@ -91,6 +112,5 @@ func Test(t *testing.T) {
 
 			fmt.Println("Issue count: " + strconv.Itoa(len(issues)))
 		})
-
 	})
 }

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -19,30 +19,24 @@ func Test(t *testing.T) {
 	s := New("PERSONAL ACCESS TOKEN HERE")
 
 	g.Describe("Github Service", func() {
-		daysOfActivity := 4
+		daysOfActivity := 1
 
-		g.It("Should find repos for RobotsAndPencils", func() {
-			repos, err := s.findActiveReposForOrganization("RobotsAndPencils", daysOfActivity)
+		g.It("Should find active repos for RobotsAndPencils", func() {
+			repos, err := s.loadActiveReposForOrganization("RobotsAndPencils", daysOfActivity)
 
 			Expect(repos).ToNot(BeNil())
 			Expect(err).To(BeNil())
-			
-			fmt.Println("Active repositories = " + strconv.Itoa(len(repos)))
 		})
-		
-		g.It("Should find open pull requests for repos in RobotsAndPencils", func() {
-			pullRequests, err := s.findOpenPRsForOrganization("RobotsAndPencils", daysOfActivity)
+
+		g.It("Should find open pull requests for active repos in RobotsAndPencils", func() {
+			pullRequests, err := s.loadOpenPRsForOrganization("RobotsAndPencils", daysOfActivity)
 
 			Expect(pullRequests).ToNot(BeNil())
 			Expect(err).To(BeNil())
-			
-			fmt.Println("Active repositories that have open PRs = " + strconv.Itoa(len(pullRequests)))
-			
-			Expect(5).To(BeEquivalentTo(4))
 		})
-		
-		g.It("Should find product backlog items in marvin", func() {
-			issues, err := s.Backlog("RobotsAndPencils", "marvin")
+
+		g.It("Should find product backlog items in pencilcase", func() {
+			issues, err := s.Backlog("RobotsAndPencils", "pencilcase")
 
 			Expect(issues).ToNot(BeNil())
 			Expect(err).To(BeNil())
@@ -55,24 +49,24 @@ func Test(t *testing.T) {
 			Expect(err).To(BeNil())
 		})
 
-		g.It("Should find in progress items in marvin", func() {
-			issues, err := s.InProgress("RobotsAndPencils", "marvin")
+		g.It("Should find in progress items in pencilcase", func() {
+			issues, err := s.InProgress("RobotsAndPencils", "pencilcase")
 
 			Expect(issues).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
 
-		g.It("Should find ready for QA items in marvin", func() {
-			issues, err := s.ReadyForQA("RobotsAndPencils", "marvin")
+		g.It("Should find ready for QA items in pencilcase", func() {
+			issues, err := s.ReadyForQA("RobotsAndPencils", "pencilcase")
+
+			Expect(issues).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		g.It("Should not find ready for review items in marvin", func() {
+			issues, err := s.ReadyForReview("RobotsAndPencils", "marvin")
 
 			Expect(issues).To(BeNil())
-			Expect(err).To(BeNil())
-		})
-
-		g.It("Should find ready for review items in pencilcase", func() {
-			issues, err := s.ReadyForReview("RobotsAndPencils", "pencilcase")
-
-			Expect(issues).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
 
@@ -86,14 +80,14 @@ func Test(t *testing.T) {
 		g.It("Should load all of the issues for gambit", func() {
 			issues, _ := s.loadIssuesForRepo("RobotsAndPencils", "gambit", "")
 
-			Expect(len(issues)).To(BeEquivalentTo(36))
+			Expect(len(issues)).To(BeEquivalentTo(59))
 		})
 
 		g.It("Should find 4 sprint tasks in gambit", func() {
 			issues, err := s.Sprint("RobotsAndPencils", "gambit")
 
 			Expect(issues).ToNot(BeNil())
-			Expect(len(issues)).To(BeEquivalentTo(3))
+			Expect(len(issues)).To(BeEquivalentTo(5))
 			Expect(err).To(BeNil())
 		})
 

--- a/robots/openpullrequests.go
+++ b/robots/openpullrequests.go
@@ -1,0 +1,117 @@
+package robots
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/RobotsAndPencils/marvin/githubservice"
+	"github.com/kelseyhightower/envconfig"
+)
+
+type OpenPullRequestsBot struct {
+}
+
+var OpenPullRequestsConfig = new(GithubConfiguration)
+
+// Loads the config file and registers the bot with the server for command /OpenPullRequests.
+func init() {
+	// Try to load the configuration from the environment and fall back to files in the filesystem
+	var c ConfigSpecification
+	err := envconfig.Process("github", &c)
+
+	if err != nil {
+		log.Println(err.Error())
+
+		// Fall back to reading from files if there is an error
+		loadOpenPullRequestsConfigFromFile()
+	} else {
+		err = json.Unmarshal([]byte(c.Config), OpenPullRequestsConfig)
+		if err != nil {
+			log.Println("error parsing config: ", err)
+			loadOpenPullRequestsConfigFromFile()
+		}
+	}
+	OpenPullRequests := &OpenPullRequestsBot{}
+	RegisterRobot("openpullrequests", OpenPullRequests)
+}
+
+func loadOpenPullRequestsConfigFromFile() {
+	flag.Parse()
+	configFile := filepath.Join(*ConfigDirectory, "github.json")
+	if _, err := os.Stat(configFile); err == nil {
+		config, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			log.Printf("ERROR: Error opening github config: %s", err)
+			return
+		}
+		err = json.Unmarshal(config, OpenPullRequestsConfig)
+		if err != nil {
+			log.Printf("ERROR: Error parsing github config: %s", err)
+			return
+		}
+	} else {
+		log.Printf("WARNING: Could not find configuration file github.json in %s", *ConfigDirectory)
+	}
+}
+
+func (r OpenPullRequestsBot) parsePayload(p *Payload) (duration string) {
+	output := strings.Split(strings.TrimSpace(p.Text), " ")
+	log.Printf("Output=" + output[0])
+	return output[0]
+}
+
+// All Robots must implement a Run command to be executed when the registered command is received.
+func (r OpenPullRequestsBot) Run(p *Payload) string {
+	// If you (optionally) want to do some asynchronous work (like sending API calls to slack)
+	// you can put it in a go routine like this
+	go r.DeferredAction(p)
+	// The string returned here will be shown only to the user who executed the command
+	// and will show up as a message from slackbot.
+	return "Calculating open pull requests that have been open for more than 1 day..."
+}
+
+func (r OpenPullRequestsBot) DeferredAction(p *Payload) {
+
+	duration := r.parsePayload(p)
+	validDurationInDays, err := strconv.Atoi(duration)
+	if err != nil {
+		validDurationInDays = 30 // If the project hasn't been updated in that time frame then we don't care
+	}
+
+	service := githubservice.New(OpenPullRequestsConfig.PersonalAccessToken)
+	pullRequests, err := service.OpenPullRequests(OpenPullRequestsConfig.Owner, validDurationInDays)
+
+	attachments := BuildAttachmentsShowPullRequests(pullRequests, err)
+
+	var text string = "Pull requests *open for more than 1 day*"
+
+	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
+	// IncomingWebhook message to slack that can be seen by everyone in the room. You can
+	// read the Slack API Docs (https://api.slack.com/) to know which fields are required, etc.
+	// You can also see what data is available from the command structure in definitions.go
+	response := &IncomingWebhook{
+		Channel:     p.ChannelID,
+		Username:    "Marvin",
+		Text:        text,
+		IconEmoji:   ":robot:",
+		UnfurlLinks: true,
+		Parse:       ParseStyleFull,
+		Markdown:    true,
+		Attachments: attachments,
+	}
+
+	response.Send()
+}
+
+func (r OpenPullRequestsBot) Description() (description string) {
+	// In addition to a Run method, each Robot must implement a Description method which
+	// is just a simple string describing what the Robot does. This is used in the included
+	// /c command which gives users a list of commands and descriptions
+	return "This is a description for openPullRequestsBot which will be displayed on /c"
+}


### PR DESCRIPTION
This brings in the ability to view long running PRs from across all our Github repositories. By default it looks for the repositories that were active in the last 30 days (assuming that if it isn't active we don't really care about it). You can override that by providing an additional argument for the number of days. I use 1 day for testing as the query can take ~10-20 seconds to complete and can get quite verbose since we've got lots of stale PRs.

You can check out some sample output on the "test" slack channel.

And if I've violated some GoLang rules... know that it is due to pure ignorance as this was my first time cutting Go code