### PR TITLE
Commits to master bot

### DIFF
--- a/githubservice/githubservice.go
+++ b/githubservice/githubservice.go
@@ -314,12 +314,12 @@ func (g *GithubService) makeIssueList(owner string, repo string, assigned string
 	return sprintIssues, err
 }
 
-func (g *GithubService) makeCommitsList(owner string, repo string, committer string, lambda func(github.RepositoryCommit, []github.RepositoryCommit) bool) ([]github.RepositoryCommit, error) {
+func (g *GithubService) makeCommitsList(owner string, repo string, committer string, lambda func(github.RepositoryCommit, []github.RepositoryCommit) bool) ([]github.RepositoryCommit, int, error) {
 
 	commits, err := g.loadCommitsForRepo(owner, repo, committer)
 
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	var masterCommits []github.RepositoryCommit
@@ -332,7 +332,7 @@ func (g *GithubService) makeCommitsList(owner string, repo string, committer str
 		}
 	}
 
-	return masterCommits, err
+	return masterCommits, len(commits), err
 }
 
 func (g *GithubService) AssignedTo(owner string, repo string, login string) ([]github.Issue, error) {
@@ -372,7 +372,7 @@ func (g *GithubService) OpenPullRequests(owner string, duration int) ([]Reposito
 	return g.loadOpenPRsForOrganization(owner, duration)
 }
 
-func (g *GithubService) CommitsToMaster(owner string, repo string) ([]github.RepositoryCommit, error) {
+func (g *GithubService) CommitsToMaster(owner string, repo string) ([]github.RepositoryCommit, int, error) {
 	return g.makeCommitsList(owner, repo, "", g.isCommitInList)
 }
 

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -108,21 +108,21 @@ func Test(t *testing.T) {
 		})
 
 		g.It("Should find commits for a repo", func() {
-			commits, err := s.loadCommitsForRepo("RobotsAndPencils", "marvin", "")
+			commits, err := s.loadCommitsForRepo("RobotsAndPencils", "marvin", "", 30)
 
 			Expect(commits).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
 
 		g.It("Should find PR commits for a repo", func() {
-			commits, err := s.loadCommitsFromAllRepoPRs("RobotsAndPencils", "marvin")
+			commits, err := s.loadCommitsFromAllRepoPRs("RobotsAndPencils", "marvin", 30)
 
 			Expect(commits).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
 
 		g.It("Should find commits to master", func() {
-			commits, total, err := s.CommitsToMaster("RobotsAndPencils", "marvin")
+			commits, total, err := s.CommitsToMaster("RobotsAndPencils", "marvin", 30)
 
 			Expect(commits).ToNot(BeNil())
 			Expect(total).ToNot(BeNil())

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -106,5 +106,26 @@ func Test(t *testing.T) {
 
 			fmt.Println("Issue count: " + strconv.Itoa(len(issues)))
 		})
+
+		g.It("Should find commits for a repo", func() {
+			commits, err := s.loadCommitsForRepo("RobotsAndPencils", "marvin", "")
+
+			Expect(commits).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		g.It("Should find PR commits for a repo", func() {
+			commits, err := s.loadCommitsFromAllRepoPRs("RobotsAndPencils", "marvin")
+
+			Expect(commits).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
+
+		g.It("Should find commits to master", func() {
+			commits, err := s.CommitsToMaster("RobotsAndPencils", "marvin")
+
+			Expect(commits).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
 	})
 }

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -122,9 +122,10 @@ func Test(t *testing.T) {
 		})
 
 		g.It("Should find commits to master", func() {
-			commits, err := s.CommitsToMaster("RobotsAndPencils", "marvin")
+			commits, total, err := s.CommitsToMaster("RobotsAndPencils", "marvin")
 
 			Expect(commits).ToNot(BeNil())
+			Expect(total).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
 	})

--- a/robots/commitstomaster.go
+++ b/robots/commitstomaster.go
@@ -72,13 +72,14 @@ func (r CommitsToMasterBot) Run(p *Payload) string {
 
 func (r CommitsToMasterBot) DeferredAction(p *Payload) {
 
+	days := 30 //default to last 30 days
 	repo := strings.TrimSpace(p.Text)
 	service := githubservice.New(CommitsToMasterConfig.PersonalAccessToken)
-	commits, totalCommits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, repo)
-	attachments =: BuildAttachmentsShowCommits(commits, err)
+	commits, totalCommits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, repo, days)
+	attachments := BuildAttachmentsShowCommits(commits, err)
 
 	var masterCommitCount = len(commits)
-	attachments = append(attachments, BuildAttachmentCommitSummary(repo, masterCommitCount, totalCommits))
+	attachments = append(attachments, BuildAttachmentCommitSummary(repo, masterCommitCount, totalCommits, days))
 
 	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
 	// IncomingWebhook message to slack that can be seen by everyone in the room. You can

--- a/robots/commitstomaster.go
+++ b/robots/commitstomaster.go
@@ -1,0 +1,103 @@
+package robots
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/RobotsAndPencils/marvin/githubservice"
+	"github.com/kelseyhightower/envconfig"
+)
+
+type CommitsToMasterBot struct {
+}
+
+var CommitsToMasterConfig = new(GithubConfiguration)
+
+// Loads the config file and registers the bot with the server for command /CommitsToMaster.
+func init() {
+	// Try to load the configuration from the environment and fall back to files in the filesystem
+	var c ConfigSpecification
+	err := envconfig.Process("github", &c)
+
+	if err != nil {
+		log.Println(err.Error())
+
+		// Fall back to reading from files if there is an error
+		loadCommitsToMasterConfigFromFile()
+	} else {
+		err = json.Unmarshal([]byte(c.Config), CommitsToMasterConfig)
+		if err != nil {
+			log.Println("error parsing config: ", err)
+			loadCommitsToMasterConfigFromFile()
+		}
+	}
+	CommitsToMaster := &CommitsToMasterBot{}
+	RegisterRobot("commitstomaster", CommitsToMaster)
+}
+
+func loadCommitsToMasterConfigFromFile() {
+	flag.Parse()
+	configFile := filepath.Join(*ConfigDirectory, "github.json")
+	if _, err := os.Stat(configFile); err == nil {
+		config, err := ioutil.ReadFile(configFile)
+		if err != nil {
+			log.Printf("ERROR: Error opening github config: %s", err)
+			return
+		}
+		err = json.Unmarshal(config, CommitsToMasterConfig)
+		if err != nil {
+			log.Printf("ERROR: Error parsing github config: %s", err)
+			return
+		}
+	} else {
+		log.Printf("WARNING: Could not find configuration file github.json in %s", *ConfigDirectory)
+	}
+}
+
+// All Robots must implement a Run command to be executed when the registered command is received.
+func (r CommitsToMasterBot) Run(p *Payload) string {
+	// If you (optionally) want to do some asynchronous work (like sending API calls to slack)
+	// you can put it in a go routine like this
+	go r.DeferredAction(p)
+	// The string returned here will be shown only to the user who executed the command
+	// and will show up as a message from slackbot.
+
+	return "Calculating commits to master for " + p.Text + "..."
+}
+
+func (r CommitsToMasterBot) DeferredAction(p *Payload) {
+
+	service := githubservice.New(CommitsToMasterConfig.PersonalAccessToken)
+	commits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, strings.TrimSpace(p.Text))
+
+	attachments := BuildAttachmentsShowCommits(commits, err)
+
+	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
+	// IncomingWebhook message to slack that can be seen by everyone in the room. You can
+	// read the Slack API Docs (https://api.slack.com/) to know which fields are required, etc.
+	// You can also see what data is available from the command structure in definitions.go
+	response := &IncomingWebhook{
+		Channel:     p.ChannelID,
+		Username:    "Marvin",
+		Text:        "Commits to master for repo *" + p.Text + "*",
+		IconEmoji:   ":robot:",
+		UnfurlLinks: true,
+		Parse:       ParseStyleFull,
+		Markdown:    true,
+		Attachments: attachments,
+	}
+
+	response.Send()
+}
+
+func (r CommitsToMasterBot) Description() (description string) {
+	// In addition to a Run method, each Robot must implement a Description method which
+	// is just a simple string describing what the Robot does. This is used in the included
+	// /c command which gives users a list of commands and descriptions
+	return "This is a description for CommitsToMasterBot which will be displayed on /c"
+}

--- a/robots/commitstomaster.go
+++ b/robots/commitstomaster.go
@@ -72,10 +72,13 @@ func (r CommitsToMasterBot) Run(p *Payload) string {
 
 func (r CommitsToMasterBot) DeferredAction(p *Payload) {
 
+	repo := strings.TrimSpace(p.Text)
 	service := githubservice.New(CommitsToMasterConfig.PersonalAccessToken)
-	commits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, strings.TrimSpace(p.Text))
+	commits, totalCommits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, repo)
+	attachments =: BuildAttachmentsShowCommits(commits, err)
 
-	attachments := BuildAttachmentsShowCommits(commits, err)
+	var masterCommitCount = len(commits)
+	attachments = append(attachments, BuildAttachmentCommitSummary(repo, masterCommitCount, totalCommits))
 
 	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
 	// IncomingWebhook message to slack that can be seen by everyone in the room. You can

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -292,3 +292,12 @@ func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err erro
 
 	return attachments
 }
+
+func BuildAttachmentCommitSummary(repo string, masterCommitCount int, totalCommits int) Attachment {
+
+	return Attachment{
+		Title: "Commits to master on " + repo,
+		Text:  strconv.Itoa(masterCommitCount) + " of " + strconv.Itoa(totalCommits) + " commits were direct to master",
+		Color: "#A0A0A0",
+	}
+}

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -275,12 +275,6 @@ func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err erro
 				}
 				attachments = append(attachments, *attachment)
 			}
-		} else {
-			attachment := &Attachment{
-				Text:  "No commits to master were found.",
-				Color: "#A0A0A0",
-			}
-			attachments = append(attachments, *attachment)
 		}
 	} else {
 		attachment := &Attachment{
@@ -293,11 +287,11 @@ func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err erro
 	return attachments
 }
 
-func BuildAttachmentCommitSummary(repo string, masterCommitCount int, totalCommits int) Attachment {
+func BuildAttachmentCommitSummary(repo string, masterCommitCount int, totalCommits int, days int) Attachment {
 
 	return Attachment{
 		Title: "Commits to master on " + repo,
-		Text:  strconv.Itoa(masterCommitCount) + " of " + strconv.Itoa(totalCommits) + " commits were direct to master",
+		Text:  "There were " + strconv.Itoa(masterCommitCount) + " of " + strconv.Itoa(totalCommits) + " commits directly to master in the last " + strconv.Itoa(days) + " days",
 		Color: "#A0A0A0",
 	}
 }

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -249,3 +249,46 @@ func BuildAttachmentsShowPullRequests(reposWithPRs []githubservice.RepositoryPul
 
 	return attachments
 }
+
+func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err error) []Attachment {
+	var attachments []Attachment
+
+	if err == nil {
+		if len(repoCommits) > 0 {
+			for _, commit := range repoCommits {
+				var author string
+				if commit.Author != nil {
+					author = "_" + *commit.Author.Login + "_"
+				} else {
+					author = "_Unknown_"
+				}
+
+				var title string = "Commit " + (*commit.SHA)[0:7]
+				var description string = "by " + author + " - " + *commit.Commit.Message
+				markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
+				attachment := &Attachment{
+					Title:      title,
+					TitleLink:  *commit.HTMLURL,
+					Text:       description,
+					Color:      "#ff1010",
+					MarkdownIn: markdownFields,
+				}
+				attachments = append(attachments, *attachment)
+			}
+		} else {
+			attachment := &Attachment{
+				Text:  "No commits to master were found.",
+				Color: "#A0A0A0",
+			}
+			attachments = append(attachments, *attachment)
+		}
+	} else {
+		attachment := &Attachment{
+			Text:  "Error: " + err.Error(),
+			Color: "#ff0000",
+		}
+		attachments = append(attachments, *attachment)
+	}
+
+	return attachments
+}

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -263,8 +263,8 @@ func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err erro
 					author = "_Unknown_"
 				}
 
-				var title string = "Commit " + (*commit.SHA)[0:7]
-				var description string = "by " + author + " - " + *commit.Commit.Message
+				var title string = (*commit.SHA)[0:7] + " - " + *commit.Commit.Message
+				var description string = commit.Commit.Author.Date.Format("January _2 3:04PM") + " by " + author
 				markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
 				attachment := &Attachment{
 					Title:      title,


### PR DESCRIPTION
Adding `/commitstomaster` bot that returns a list of all commits in the master branch for a given repository which are not part of a Pull Request.

Usage:
send a POST to the slack endpoint with the payload variables
`command`: `/commitstomaster`
`text`: `repositoryname`

Possible enhancements:
Only include commits that are within a certain date range (ie last 30 days)

Connects #19 