### PR TITLE
Commits to master weekly report

### DIFF
--- a/githubservice/githubservice.go
+++ b/githubservice/githubservice.go
@@ -225,12 +225,7 @@ func (g *GithubService) loadCommitsFromAllRepoPRs(owner string, repo string, day
 			}
 
 			for _, prCommit := range prCommits {
-				timeSinceCommit := time.Now().Sub(*prCommit.Commit.Author.Date).Hours()
-				if timeSinceCommit <= float64(days)*24 {
-					allPRCommits = append(allPRCommits, prCommit)
-				} else {
-					break
-				}
+				allPRCommits = append(allPRCommits, prCommit)
 			}
 
 			if prResp.NextPage == 0 {

--- a/githubservice/githubservice.go
+++ b/githubservice/githubservice.go
@@ -195,6 +195,8 @@ func (g *GithubService) loadCommitsFromAllRepoPRs(owner string, repo string, day
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 
+	remainingPRsAreOlder := false
+
 	for {
 		pullRequests, resp, err := client.PullRequests.List(owner, repo, opt)
 		if err != nil {
@@ -203,6 +205,15 @@ func (g *GithubService) loadCommitsFromAllRepoPRs(owner string, repo string, day
 		}
 
 		for _, pullRequest := range pullRequests {
+
+			timeSincePRCreated := time.Now().Sub(*pullRequest.CreatedAt).Hours()
+
+			if timeSincePRCreated > float64(days)*24 {
+				//PR is older than time box. Assuming a sorted list it is safe to stop processing.
+				remainingPRsAreOlder = true
+				break
+			}
+
 			prOpt := &github.ListOptions{
 				PerPage: 100,
 			}
@@ -214,9 +225,11 @@ func (g *GithubService) loadCommitsFromAllRepoPRs(owner string, repo string, day
 			}
 
 			for _, prCommit := range prCommits {
-				timeSince := time.Now().Sub(*prCommit.Commit.Author.Date).Hours()
-				if timeSince <= float64(days)*24 {
+				timeSinceCommit := time.Now().Sub(*prCommit.Commit.Author.Date).Hours()
+				if timeSinceCommit <= float64(days)*24 {
 					allPRCommits = append(allPRCommits, prCommit)
+				} else {
+					break
 				}
 			}
 
@@ -227,7 +240,7 @@ func (g *GithubService) loadCommitsFromAllRepoPRs(owner string, repo string, day
 			prOpt.Page = prResp.NextPage
 		}
 
-		if resp.NextPage == 0 {
+		if resp.NextPage == 0 || remainingPRsAreOlder {
 			break
 		}
 
@@ -319,16 +332,56 @@ func (g *GithubService) makeIssueList(owner string, repo string, assigned string
 	return sprintIssues, err
 }
 
-func (g *GithubService) makeCommitsList(owner string, repo string, committer string, lambda func(github.RepositoryCommit, []github.RepositoryCommit) bool, days int) ([]github.RepositoryCommit, int, error) {
+func (g *GithubService) makeCommitsList(owner string, repo string, committer string, lambda func(github.RepositoryCommit, []github.RepositoryCommit) bool, days int) (map[string][]github.RepositoryCommit, int, error) {
 
+	totalCommits := 0
+	repoToMasterCommits := make(map[string][]github.RepositoryCommit)
+
+	if repo == "" {
+		//summary of commits from all repos
+		repositories, err := g.loadActiveReposForOrganization(owner, days)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		for _, repository := range repositories {
+			repoName := *repository.Name
+			masterCommits, totalRepoCommits, err := g.masterCommitsForSingleRepo(owner, repoName, committer, lambda, days)
+
+			if err != nil {
+				return nil, 0, err
+			}
+
+			if len(masterCommits) > 0 {
+				repoToMasterCommits[repoName] = masterCommits
+				totalCommits += totalRepoCommits
+			}
+		}
+	} else {
+		//single repo query
+		masterCommits, totalRepoCommits, err := g.masterCommitsForSingleRepo(owner, repo, committer, lambda, days)
+
+		if err != nil {
+			return nil, 0, err
+		}
+
+		repoToMasterCommits[repo] = masterCommits
+		totalCommits += totalRepoCommits
+	}
+
+	return repoToMasterCommits, totalCommits, nil
+}
+
+func (g *GithubService) masterCommitsForSingleRepo(owner string, repo string, committer string, lambda func(github.RepositoryCommit, []github.RepositoryCommit) bool, days int) ([]github.RepositoryCommit, int, error) {
 	commits, err := g.loadCommitsForRepo(owner, repo, committer, days)
+	allPRCommits, err := g.loadCommitsFromAllRepoPRs(owner, repo, days)
 
 	if err != nil {
 		return nil, 0, err
 	}
 
-	var masterCommits []github.RepositoryCommit
-	allPRCommits, err := g.loadCommitsFromAllRepoPRs(owner, repo, days)
+	masterCommits := make([]github.RepositoryCommit, 0)
+
 	for _, commit := range commits {
 		// Do not include merge commits
 		// Only include commits that are not part of a PR
@@ -377,7 +430,7 @@ func (g *GithubService) OpenPullRequests(owner string, duration int) ([]Reposito
 	return g.loadOpenPRsForOrganization(owner, duration)
 }
 
-func (g *GithubService) CommitsToMaster(owner string, repo string, days int) ([]github.RepositoryCommit, int, error) {
+func (g *GithubService) CommitsToMaster(owner string, repo string, days int) (map[string][]github.RepositoryCommit, int, error) {
 	return g.makeCommitsList(owner, repo, "", g.isCommitInList, days)
 }
 

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -128,5 +128,13 @@ func Test(t *testing.T) {
 			Expect(total).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
+
+		g.It("Commits to master for all repos", func() {
+			commits, total, err := s.CommitsToMaster("RobotsAndPencils", "", 7)
+
+			Expect(commits).ToNot(BeNil())
+			Expect(total).ToNot(BeNil())
+			Expect(err).To(BeNil())
+		})
 	})
 }

--- a/robots/commitstomaster.go
+++ b/robots/commitstomaster.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/RobotsAndPencils/marvin/githubservice"
@@ -84,15 +85,16 @@ func (r CommitsToMasterBot) DeferredAction(p *Payload) {
 		days = 7 //when searching all repos use a time box of 7 days
 	}
 
-	responseText := "Commits to master weekly summary"
+	responseText := "Commits to master in the last " + strconv.Itoa(days) + " days"
 	service := githubservice.New(CommitsToMasterConfig.PersonalAccessToken)
-	reposToCommits, totalCommits, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, repo, days)
-	attachments := BuildAttachmentsShowCommits(reposToCommits, err)
+	reposToCommits, _, err := service.CommitsToMaster(CommitsToMasterConfig.Owner, repo, days)
+	var attachments []Attachment
 
 	if repo != "" {
-		responseText = "Commits to master for repo *" + repo + "*"
-		var masterCommitCount = len(reposToCommits[repo])
-		attachments = append(attachments, BuildAttachmentCommitSummary(repo, masterCommitCount, totalCommits, days))
+		responseText = "Commits to master for repo *" + repo + "* in the last " + strconv.Itoa(days) + " days"
+		attachments = BuildAttachmentsShowCommits(reposToCommits, err)
+	} else {
+		attachments = BuildAttachmentCommitSummaryByRepo(reposToCommits, CommitsToMasterConfig.Owner, days)
 	}
 
 	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"time"
 
@@ -252,9 +253,17 @@ func BuildAttachmentsShowPullRequests(reposWithPRs []githubservice.RepositoryPul
 
 func BuildAttachmentsShowCommits(repos map[string][]github.RepositoryCommit, err error) []Attachment {
 	var attachments []Attachment
+	sortedRepoNames := make([]string, len(repos))
+
+	for repoName := range repos {
+		sortedRepoNames = append(sortedRepoNames, repoName)
+	}
+	sort.Strings(sortedRepoNames)
 
 	if err == nil {
-		for repoName, repoCommits := range repos {
+		for _, repoName := range sortedRepoNames {
+			repoCommits := repos[repoName]
+
 			if len(repoCommits) > 0 {
 				for _, commit := range repoCommits {
 					var author string

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -250,30 +250,32 @@ func BuildAttachmentsShowPullRequests(reposWithPRs []githubservice.RepositoryPul
 	return attachments
 }
 
-func BuildAttachmentsShowCommits(repoCommits []github.RepositoryCommit, err error) []Attachment {
+func BuildAttachmentsShowCommits(repos map[string][]github.RepositoryCommit, err error) []Attachment {
 	var attachments []Attachment
 
 	if err == nil {
-		if len(repoCommits) > 0 {
-			for _, commit := range repoCommits {
-				var author string
-				if commit.Author != nil {
-					author = "_" + *commit.Author.Login + "_"
-				} else {
-					author = "_Unknown_"
-				}
+		for repoName, repoCommits := range repos {
+			if len(repoCommits) > 0 {
+				for _, commit := range repoCommits {
+					var author string
+					if commit.Author != nil {
+						author = "_" + *commit.Author.Login + "_"
+					} else {
+						author = "_Unknown_"
+					}
 
-				var title string = (*commit.SHA)[0:7] + " - " + *commit.Commit.Message
-				var description string = commit.Commit.Author.Date.Format("January _2 3:04PM") + " by " + author
-				markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
-				attachment := &Attachment{
-					Title:      title,
-					TitleLink:  *commit.HTMLURL,
-					Text:       description,
-					Color:      "#ff1010",
-					MarkdownIn: markdownFields,
+					var title string = repoName + "/" + (*commit.SHA)[0:7] + " - " + *commit.Commit.Message
+					var description string = commit.Commit.Author.Date.Format("January _2 3:04PM") + " by " + author
+					markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
+					attachment := &Attachment{
+						Title:      title,
+						TitleLink:  *commit.HTMLURL,
+						Text:       description,
+						Color:      "#ff1010",
+						MarkdownIn: markdownFields,
+					}
+					attachments = append(attachments, *attachment)
 				}
-				attachments = append(attachments, *attachment)
 			}
 		}
 	} else {

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/RobotsAndPencils/marvin/githubservice"
@@ -298,11 +299,40 @@ func BuildAttachmentsShowCommits(repos map[string][]github.RepositoryCommit, err
 	return attachments
 }
 
-func BuildAttachmentCommitSummary(repo string, masterCommitCount int, totalCommits int, days int) Attachment {
+func BuildAttachmentCommitSummaryByRepo(reposToCommits map[string][]github.RepositoryCommit, owner string, days int) []Attachment {
+	var attachments []Attachment
 
-	return Attachment{
-		Title: "Commits to master on " + repo,
-		Text:  "There were " + strconv.Itoa(masterCommitCount) + " of " + strconv.Itoa(totalCommits) + " commits directly to master in the last " + strconv.Itoa(days) + " days",
-		Color: "#A0A0A0",
+	for repoName, commitsToMaster := range reposToCommits {
+		var commitList []string
+		for _, commit := range commitsToMaster {
+			commitList = append(commitList, (*commit.SHA)[0:7])
+		}
+		commitListString := strings.Join(commitList, ", ")
+		commitWording := "commits"
+		if len(commitList) == 1 {
+			commitWording = "commit"
+		}
+		attachment := &Attachment{
+			Title:      repoName,
+			TitleLink:  "https://www.github.com/" + owner + "/" + repoName + "/commits/master",
+			Text:       strconv.Itoa(len(commitList)) + " " + commitWording + ": " + commitListString,
+			Color:      colorForMasterCommitCount(len(commitList)),
+			MarkdownIn: []MarkdownField{MarkdownFieldText},
+		}
+		attachments = append(attachments, *attachment)
+	}
+
+	return attachments
+}
+
+func colorForMasterCommitCount(commitCount int) string {
+	if commitCount > 10 {
+		return "#FF1010"
+	} else if commitCount > 5 {
+		return "#FF7222"
+	} else if commitCount > 0 {
+		return "#FFD334"
+	} else {
+		return "#A0A0A0"
 	}
 }


### PR DESCRIPTION
Added the option that when a repo is not specified it will generate a report for all active repos and will report on commits made in the last 7 days.