### PR TITLE
Updates for long running PR report

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You need to create a bunch of Slack Slash commands, each pointing at the same UR
 /readyforqa [repo]
 /qapass [repo]
 /assigned [repo|*] [login]
-/openpullrequests [days]
+/openpullrequests [daysPROpen] [daysSinceLastProjectActivity]
 /commitstomaster [repo]
 ```
 

--- a/githubservice/githubservice_test.go
+++ b/githubservice/githubservice_test.go
@@ -29,7 +29,7 @@ func Test(t *testing.T) {
 		})
 
 		g.It("Should find open pull requests for active repos in RobotsAndPencils", func() {
-			pullRequests, err := s.loadOpenPRsForOrganization("RobotsAndPencils", daysOfActivity)
+			pullRequests, err := s.loadOpenPRsForOrganization("RobotsAndPencils", daysOfActivity, daysOfActivity)
 
 			Expect(pullRequests).ToNot(BeNil())
 			Expect(err).To(BeNil())

--- a/robots/openpullrequests.go
+++ b/robots/openpullrequests.go
@@ -60,10 +60,27 @@ func loadOpenPullRequestsConfigFromFile() {
 	}
 }
 
-func (r OpenPullRequestsBot) parsePayload(p *Payload) (duration string) {
+func (r OpenPullRequestsBot) parsePayload(p *Payload) (daysPROpen int, projectLastActiveDays int) {
 	output := strings.Split(strings.TrimSpace(p.Text), " ")
-	log.Printf("Output=" + output[0])
-	return output[0]
+
+	var err error
+	var validDaysPROpen int = 1
+	if len(output) >= 1 {
+		validDaysPROpen, err = strconv.Atoi(output[0])
+		if err != nil {
+			validDaysPROpen = 1 // Defaults to being open longer than 1 day
+		}
+	}
+
+	var validDaysSinceLastProjectActivity int = 30
+	if len(output) >= 2 {
+		validDaysSinceLastProjectActivity, err = strconv.Atoi(output[1])
+		if err != nil {
+			validDaysSinceLastProjectActivity = 30 // Defaults to projects with activity in the last 30 days
+		}
+	}
+
+	return validDaysPROpen, validDaysSinceLastProjectActivity
 }
 
 // All Robots must implement a Run command to be executed when the registered command is received.
@@ -71,25 +88,24 @@ func (r OpenPullRequestsBot) Run(p *Payload) string {
 	// If you (optionally) want to do some asynchronous work (like sending API calls to slack)
 	// you can put it in a go routine like this
 	go r.DeferredAction(p)
+
+	daysPROpen, daysSinceLastProjectActivity := r.parsePayload(p)
+
 	// The string returned here will be shown only to the user who executed the command
 	// and will show up as a message from slackbot.
-	return "Calculating open pull requests that have been open for more than 1 day..."
+	return "Finding pull requests that have been open longer than " + strconv.Itoa(daysPROpen) + " days in projects with activity in the last " + strconv.Itoa(daysSinceLastProjectActivity) + " days..."
 }
 
 func (r OpenPullRequestsBot) DeferredAction(p *Payload) {
 
-	duration := r.parsePayload(p)
-	validDurationInDays, err := strconv.Atoi(duration)
-	if err != nil {
-		validDurationInDays = 30 // If the project hasn't been updated in that time frame then we don't care
-	}
+	daysPROpen, daysSinceLastProjectActivity := r.parsePayload(p)
 
 	service := githubservice.New(OpenPullRequestsConfig.PersonalAccessToken)
-	pullRequests, err := service.OpenPullRequests(OpenPullRequestsConfig.Owner, validDurationInDays)
+	pullRequests, err := service.OpenPullRequests(OpenPullRequestsConfig.Owner, daysPROpen, daysSinceLastProjectActivity)
 
 	attachments := BuildAttachmentsShowPullRequests(pullRequests, err)
 
-	var text string = "Pull requests *open for more than 1 day*"
+	var text string = "Pull requests *open for more than " + strconv.Itoa(daysPROpen) + " day(s)*"
 
 	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
 	// IncomingWebhook message to slack that can be seen by everyone in the room. You can

--- a/robots/openpullrequests.go
+++ b/robots/openpullrequests.go
@@ -105,7 +105,7 @@ func (r OpenPullRequestsBot) DeferredAction(p *Payload) {
 
 	attachments := BuildAttachmentsShowPullRequests(pullRequests, err)
 
-	var text string = "Pull requests *open for more than " + strconv.Itoa(daysPROpen) + " day(s)*"
+	var text string = "Pull requests open for more than " + strconv.Itoa(daysPROpen) + " days in projects with activity in the last " + strconv.Itoa(daysSinceLastProjectActivity) + " days..."
 
 	// Let's use the IncomingWebhook struct defined in definitions.go to form and send an
 	// IncomingWebhook message to slack that can be seen by everyone in the room. You can

--- a/robots/shared.go
+++ b/robots/shared.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RobotsAndPencils/marvin/githubservice"
 	"github.com/google/go-github/github"
 	"github.com/kelseyhightower/envconfig"
 )
@@ -192,47 +191,42 @@ func BuildAttachmentsShowRepo(issues []github.Issue, showrepo bool, showAssigned
 	return attachments
 }
 
-func BuildAttachmentsShowPullRequests(reposWithPRs []githubservice.RepositoryPullRequest, err error) []Attachment {
+func BuildAttachmentsShowPullRequests(openPRs []github.PullRequest, err error) []Attachment {
 	var attachments []Attachment
 
 	if err == nil {
-		if len(reposWithPRs) > 0 {
-			for _, item := range reposWithPRs {
-				for _, pullRequest := range item.PullRequests {
-					var numberOfDays = time.Since(*pullRequest.CreatedAt).Hours() / 24
-					if numberOfDays < 1 {
-						break // These PRs are too new for us to care about
-					}
+		if len(openPRs) > 0 {
+			for _, pullRequest := range openPRs {
+				var numberOfDays = time.Since(*pullRequest.CreatedAt).Hours() / 24
 
-					// Setup a color gradient to quickly show PR age for someone scanning the list
-					var colour = "#ffe7e7"
-					if numberOfDays > 30 {
-						colour = "#ff1010"
-					} else if numberOfDays > 7 {
-						colour = "#ff5757"
-					} else if numberOfDays > 3 {
-						colour = "#ff9f9f"
-					}
-
-					var assigned string
-					if pullRequest.User != nil {
-						assigned = "_" + *pullRequest.User.Login + "_"
-					} else {
-						assigned = "_Unassigned_"
-					}
-
-					var title string = "PR #" + strconv.Itoa(*pullRequest.Number) + " - " + *pullRequest.Title
-					var description string = strconv.FormatFloat(numberOfDays, 'f', 0, 64) + " days open in *" + *item.Repository.Name + "* by " + assigned
-					markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
-					attachment := &Attachment{
-						Title:      title,
-						TitleLink:  *pullRequest.HTMLURL,
-						Text:       description,
-						Color:      colour,
-						MarkdownIn: markdownFields,
-					}
-					attachments = append(attachments, *attachment)
+				// Setup a color gradient to quickly show PR age for someone scanning the list
+				var colour = "#ffe7e7"
+				if numberOfDays > 30 {
+					colour = "#ff1010"
+				} else if numberOfDays > 7 {
+					colour = "#ff5757"
+				} else if numberOfDays > 3 {
+					colour = "#ff9f9f"
 				}
+
+				var assigned string
+				if pullRequest.User != nil {
+					assigned = "_" + *pullRequest.User.Login + "_"
+				} else {
+					assigned = "_Unassigned_"
+				}
+
+				var title string = "PR #" + strconv.Itoa(*pullRequest.Number) + " - " + *pullRequest.Title
+				var description string = "*" + strconv.FormatFloat(numberOfDays, 'f', 0, 64) + " days in " + *pullRequest.Head.Repo.Name + "* created by " + assigned
+				markdownFields := []MarkdownField{MarkdownFieldTitle, MarkdownFieldText}
+				attachment := &Attachment{
+					Title:      title,
+					TitleLink:  *pullRequest.HTMLURL,
+					Text:       description,
+					Color:      colour,
+					MarkdownIn: markdownFields,
+				}
+				attachments = append(attachments, *attachment)
 			}
 		} else {
 			attachment := &Attachment{


### PR DESCRIPTION
Connects #26
Connects #20
## How to test
1. You could set this up and run it locally but maybe its just a code review for now and check out the latest output in the Test channel in Slack
2. The call will accepts up to two input parameters
   `/openpullrequests [daysPROpen] [daysSinceLastProjectActivity]`
3. The results are only sorted age (no longer grouped by project)
## Areas of the app affected
- Slack /openpullrequests command
